### PR TITLE
Making blog post header link to homepage

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -19,7 +19,7 @@ class BlogPostTemplate extends React.Component {
       <section id="header">
           <div className="container">
               {/* <!-- Logo --> */}
-              <h1 id="logo"><a href="index.html">Junior Dev Struggle Blog</a></h1>
+              <h1 id="logo"><Link to="/">Junior Dev Struggle Blog</Link></h1>
           </div>
       </section>
 


### PR DESCRIPTION
Blog post header was an incorrect link to the static page's index.html. Needed to use Gatsby Link api to actually link to the homepage