### PR TITLE
Fix for duplicated blog post descriptions plus a style update

### DIFF
--- a/src/components/blogpost/Post.css
+++ b/src/components/blogpost/Post.css
@@ -1,0 +1,9 @@
+
+
+
+.summary {
+	font-size: 1.25em;
+	text-align: left;
+	margin-top: 1em;
+}
+

--- a/src/components/blogpost/Post.js
+++ b/src/components/blogpost/Post.js
@@ -1,25 +1,23 @@
 import React from "react"
+import "./Post.css"
 
 const Post = ({ title, author, description, date, body }) => {
-  return (
-    <article className="box post">
-     <header style={{marginBottom:'2em'}}>
-          <h2 style={{marginBottom:0}}>{title}</h2>
-        {description}
-          <h6>
-            {author}
-          </h6>
-          <h6>
-          {date}
-          </h6>
-        </header>
-      {/* <span className="image featured">
-      <img src="images/pic04.jpg" alt="" />
-    </span> */}
-      <p>{description}</p>
-      <div dangerouslySetInnerHTML={{ __html: body }} />
-    </article>
-  )
+    return (
+        <article className="box post">
+            <header style={{ marginBottom: "2em" }}>
+                <h2 style={{ marginBottom: 0 }}>{title}</h2>
+                <p className="summary">{description}</p>
+                <h6>{author}</h6>
+                <h6>{date}</h6>
+            </header>
+            {/*
+                <span className="image featured">
+                    <img src="images/pic04.jpg" alt="" />
+                </span>
+            */}
+            <div dangerouslySetInnerHTML={{ __html: body }} />
+        </article>
+    )
 }
 
 export default Post

--- a/static/main.css
+++ b/static/main.css
@@ -23,11 +23,13 @@ section, summary, time, mark, audio, video {
 	border: 0;
 	font-size: 100%;
 	font: inherit;
-	vertical-align: baseline;}
+	vertical-align: baseline;
+}
 
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
-	display: block;}
+	display: block;
+}
 
 body {
 	line-height: 1;
@@ -1934,9 +1936,11 @@ input, select, textarea {
 			letter-spacing: 3px;
 			text-align: center;
 		}
+
 /* Logo */
+
 #logo{
-padding:1.5em 0;
+	padding:1.5em 0;
 }
 
 /* Nav */


### PR DESCRIPTION
This pull request fixes #71, removing the duplicate blog post description that appears after the author and date text in blog posts.  I also added a special treat by adding some bonus styling so that the blog post description stands out a bit more.

Let me know if there are any problems!  Thanks.